### PR TITLE
Adding open graph meta tags for social sharing.

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -7,6 +7,10 @@
 		<script src="js/vendor/modernizr.js"></script>
 		<script src="//use.typekit.net/gfs5vqd.js"></script>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta property="og:title" content="The LGBTQ in Technology Slack" />
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="http://lgbtq.technology/" />
+		<meta property="og:description" content="The LGBTQ in Technology Slack is a safe, confidential space for LGBTQ people in technology to chat and support each other." />
 		<script>try{Typekit.load();}catch(e){}</script>
 	</head>
 


### PR DESCRIPTION
I am not at all attached to the verbiage for the description, just dropped in a sensible default. 

An og:image would likely enhance clickthrough rates for social sharing.
