### PR TITLE
Add COC line for identity statements for groups of people

### DIFF
--- a/coc.md
+++ b/coc.md
@@ -25,6 +25,7 @@ layout: page
 			<div class="medium-6 columns">
 				<ul>
 					<li>Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, immigration status, religion, or other identity marker. This includes anti-Indigenous/Nativeness and anti-Blackness.</li>
+					<li>Using statements of identity to include other people without their concent</li>
 					<li>Unwelcome comments regarding a person&rsquo;s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.</li>
 					<li>Deliberate misgendering or use of &ldquo;dead&rdquo; or rejected names</li>
 					<li>Gratuitous or off-topic sexual images or behaviour in spaces where they&rsquo;re not appropriate</li>


### PR DESCRIPTION
Not everyone always feels comfortable when a group of people is referred to by one identity statement to refer to them all. They shouldn't be used to refer to people without their permission.
