### PR TITLE
Added CoC clause about questioning labels

### DIFF
--- a/coc.md
+++ b/coc.md
@@ -26,6 +26,7 @@ layout: page
 				<ul>
 					<li>Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, age, race, national origin, ethnic origin, nationality, immigration status, language, religion or lack thereof, or other identity marker. This includes anti-Indigenous/Nativeness and anti-Blackness.</li>
 					<li>Unwelcome comments regarding a person&rsquo;s lifestyle choices and practices, including those related to food, health, parenting, relationships, drugs, and employment.</li>
+					<li><a href="/coc.html#discussions-of-labels">Questioning or challenging someone&rsquo;s stated self-identity or chosen labels</a>, even if they conflict with your own views. For example, discussions about bi vs pan, trans vs trans*, or whether grey/demisexual people are asexual, <b>even if well-intentioned</b></li>
 					<li>Deliberate misgendering or use of &ldquo;dead&rdquo; or rejected names</li>
 					<li>Gratuitous or off-topic sexual images or behaviour in spaces where they&rsquo;re not appropriate</li>
 					<li>Physical contact and simulated physical contact (eg, textual descriptions like &ldquo;<em>hug</em>&rdquo; or &ldquo;<em>backrub</em>&rdquo;) without consent or after a request to stop.</li>

--- a/culture.md
+++ b/culture.md
@@ -41,6 +41,16 @@ There is an active #polyamory group.
 
 We have a #genderqueer group, as well as our #trans channels being explicitly genderqueer-friendly. We work to not assume binaries, as a great many of us are more complex than binaries can express.
 
+Discussion of Labels
+--------------------
+
+The rule in the Code of Conduct about avoiding discussions about identity labels may seem odd at first, but it comes with some history.
+
+There have been recurring discussions about some labels over the lifetime of the slack, particularly when it came to using "bi(sexual/romantic)" vs "pan(sexual/romantic)" as an identity label. Both of these labels may mean different things, and the discussion in the LGBTQ community involving them can be particularly contentious. Our experience with these discussions was that it was very easy to be accusative or dismissive of other (for example, implying or stating that bi-identifying individuals or their label are inherently against trans or non-binary people). These discussions were often more disruptive and stressful than fruitful, and it was clear that sometimes the larger context was intentionally or accidentally ignored (for example, the erasure that both bi and pan people so often face in the queer community).
+
+It is a policy of this community that people's own identities (and corresponding labels) must be respected as presented, and since there did not seem to be a clear way to prevent the cycle of challenging and relitigating the issue, a decision was made to ban that, and any such discussion -- this now includes any discussion related to trans vs trans\*, lesbian vs bi, 'gay' and 'queer' as generics, etc. Note that this only applies for self-identification. Forcibly applying a label that you think is fitting to someone who does not self-identify that way is still considered harassment as per our Code of Conduct.
+
+If you are unsure what a label means, feel free to research it externally or, if the person who used the label clearly consents to the conversation, ask them *in private* for a simple clarification, but understand that the CoC will most likely not favor you if the conversation goes awry. *Do not have these discussions in open channels*. Because of their inherent complexity, it is too easy to step on toes even if you don't mean to, in very serious, hurtful ways.
 
 Free Slack Limits
 ---------


### PR DESCRIPTION
The conclusion seemed to be that talking about bi vs pan, trans vs trans*, etc, are not productive or positive conversations in the slack, after much discussion and various attempts to reconcile the involved issues.
