### PR TITLE
Enable TLS-based signups

### DIFF
--- a/index.md
+++ b/index.md
@@ -13,7 +13,7 @@ layout: page
 	<div class="medium-6 columns">
 		<h2>How do I join?</h2>
 		<p>The Slack is invitation-only, but invitations are freely granted. You can request one from any existing member or by filling out this form: </p>
-		<form action="http://api.wealljs.org/signup" method="POST">
+		<form action="https://api.wealljs.org/signup" method="POST">
 			<label><span>Name: </span><input name="name" required type="text" class="input-field"></label>
 			<label><span>Email: </span><input name="email" required type="email" class="input-field"></label>
 			<label><span>Twitter (optional): </span><input name="twitter" type="text" class="input-field"></label>


### PR DESCRIPTION
api.wealljs.org is now https-enabled, so this updates the POST URL