### PR TITLE
No generalizing about groups you do not belong to

### DIFF
--- a/coc.md
+++ b/coc.md
@@ -40,6 +40,7 @@ layout: page
 				<ul>
 					<li>No <a href='#harassment'>harassment</a>.</li>
 					<li>No <a href="/culture.html#discussion-of-labels">questioning or challenging someone&rsquo;s stated self-identity or chosen labels</a>, even if they conflict with your own views. For example, discussions about bi vs pan, trans vs trans*, or whether grey/demisexual people are asexual, <b>even if well-intentioned</b></li>
+					<li>No making general statements about groups you do not belong to.</li>
 					<li>No incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm</li>
 					<li>No deliberate &ldquo;outing&rdquo; of any aspect of a person&rsquo;s identity without their consent except as necessary to protect vulnerable people from intentional abuse</li>
 					<li>No publication of non-harassing private communication </li>


### PR DESCRIPTION
This is intended as broad strokes best practice.

Men arguing about what 'women' are like is usually sexist.

Gentiles making statements about what Jews are like is usually antisemitic.

Even against the grain of oppression, this isn't great to have in a community. Demonizing entire groups of people is not a way to build healthy community.

Transgender people generalizing about what all cisgender people are like trivialize those on the boundary — a boundary that historically moved around significantly. It also negatively affects those working up the courage to come out.

Critique of whiteness, anti-blackness, sexism, racism, compulsory gender conformance, compulsory heterosexuality, and of toxic masculinity are not generalizations, nor about groups of people specifcally, but instead about the social structures created.